### PR TITLE
Retirar logo do telegram salva em markdown

### DIFF
--- a/docs/anime.md
+++ b/docs/anime.md
@@ -92,7 +92,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### 🧲 [Dark Mahou](https://darkmahou.org/)
 - [Verificação de segurança da URL](https://www.urlvoid.com/scan/darkmahou.org/)
 
-### 🌟🧲 [Nyaa.si](https://nyaa.si/) / [Nyaa.land](https://nyaa.land/)
+### 🌟 [Nyaa.si](https://nyaa.si/) / [Nyaa.land](https://nyaa.land/)
 - Focado em mídias asiáticas (_japonês, chinês, coreano_).
 - [Verificação de segurança da URL](https://www.urlvoid.com/scan/nyaa.si/)
 

--- a/docs/educacional.md
+++ b/docs/educacional.md
@@ -159,7 +159,7 @@ A educação é o processo de adquirir conhecimento, habilidades e valores funda
 
 - Variedade de livros para kindle de maneira organizada.
 
-## ![](public/images/telegram.png) ➜ No Telegram
+## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram
 
 ### 🔗 [Polemic Knowledge Clone](https://t.me/+-eUQNwLw9G5mNDUx)
 

--- a/docs/explicito.md
+++ b/docs/explicito.md
@@ -12,6 +12,8 @@
 
 **[9xbuddy](https://9xbuddy.site/)** — Faz o download de vídeos de quase todos os sites adultos.
 
+**[PriivaC Downloader](https://t.me/tgDownPrivacyBot)** - Download de mídias de assinaturas do Privacy.
+
 **[Hottok](https://t.me/hottoknowbot)** — Bot do Telegram que desnuda fotos.
 
 **[Only Fans Data Scrapper](https://github.com/DIGITALCRIMINAL/OnlyFans)**

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -229,7 +229,7 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/podnapisi.net/) 
 
 
-## 📑 Grupos/Canais no Telegram  
+## ![](https://files.catbox.moe/7ad7g5.png) No Telegram  
 ### 🌟 [Polemic Filmes](https://t.me/polemicfilmes) 
 ### [Cadê o Filme 7.0](https://t.me/+3j6I2jzuik1hMjgx)  
 

--- a/docs/jogos.md
+++ b/docs/jogos.md
@@ -23,7 +23,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brazilalliance.com.br/)
 ### 🔗 [Tribo Gamer](https://tribogamer.com/traducoes/)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tribogamer.com/)
-### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [![](public/images/telegram.png)](https://t.me/CentralDeTraducoes) 
+### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/CentralDeTraducoes) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
 ### 🔗 [Fórum RHDNBR](https://www.romhacking.net.br/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/romhacking.net.br/)
@@ -300,7 +300,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - O Steam Verde é uma plataforma online de jogos para PC e Android, oferecendo downloads via torrent com uma interface organizada. Conta com uma comunidade ativa que fornece tutoriais e suporte, além de manter os usuários informados sobre lançamentos. O site possui proteção antivírus e é baseado na plataforma segura Invision Community.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/steamverde.net)
 
-### 🧲 [online-fix](https://online-fix.me/) [![](public/images/telegram.png)](https://t.me/s/onlinefix)
+### 🧲 [online-fix](https://online-fix.me/) [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/s/onlinefix)
 
 - Jogue jogos online pirata com seus amigos, de forma gratuita com suporte de convite via Steam.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/online-fix.me/)

--- a/docs/livros.md
+++ b/docs/livros.md
@@ -257,7 +257,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Um utilitário da Web que obtém um URL de uma biblioteca Adobe Font e extrai a fonte do banco de dados.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/badnoise.net/)
 
-## ![](public/images/telegram.png) ➜ No Telegram 
+## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram 
 ### 🤖 [Lestrad - Bibliotecário](https://t.me/lestrad_repost_bot)
 ### 🔗 [Banca BR](https://t.me/BancaBR)
 ### 🔗 [ITSBooks](https://t.me/ITSBooks)

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -440,7 +440,7 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 - App para instalar Spotify sem anúncios.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/xmanagerapp.com/)
 
-## ![](public/images/telegram.png) ➜ No Telegram
+## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram
 
 ### 🔗 [AlveeMods](https://t.me/AlveeMods) 
 - Apks modificados

--- a/docs/sites-geral.md
+++ b/docs/sites-geral.md
@@ -57,15 +57,15 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 
 ## 📑 ➜ Telegram
 
-### ![](public/images/telegram.png) [Pirataria](https://t.me/trackerslist)
+### ![](https://files.catbox.moe/7ad7g5.png) [Pirataria](https://t.me/trackerslist)
 
 - Participe do nosso canal oficial!
 
-### ![](public/images/telegram.png) [CopyrightBR](https://t.me/CopyrightBR)
+### ![](https://files.catbox.moe/7ad7g5.png) [CopyrightBR](https://t.me/CopyrightBR)
 
 - Criado com o intuito de compartilhar notícias e releases da cena pirata brasileira. Contém avisos sobre warez/trackers abertos e muito mais.
 
-### ![](public/images/telegram.png) [UnCopy Group](https://t.me/UnCopyGroup)
+### ![](https://files.catbox.moe/7ad7g5.png) [UnCopy Group](https://t.me/UnCopyGroup)
 
 - Grupo para quem busca material e papo de qualidade sobre p2p e a scene no geral.
 

--- a/docs/warez.md
+++ b/docs/warez.md
@@ -11,7 +11,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Mídia digital, aplicativos para dispositivos móveis e pirataria voltada a educação. Aberto para cadastros. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/megaturbo.org/)
 
-### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [![](public/images/telegram.png)](https://t.me/filewarezclub)
+### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/filewarezclub)
 
 - Livros jurídicos, filmes, modelos 3D. Cadastro apenas com convite. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/filewarez.club/)


### PR DESCRIPTION
Pois quebra a linha quando usada em título (###).

Como não é possível compilar com o HTML, passei a imagem para o [catbox](https://files.catbox.moe/7ad7g5.png).

Adicionado na seção adulta:

- [PriivaC Downloader](https://t.me/tgDownPrivacyBot) - Download de mídias de assinaturas do Privacy.