### PR TITLE
PopUpOFF

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,7 +86,7 @@ export default {
           { text: "⚙️ Softwares", link: "softwares" },
           { text: "⚽ Esportes", link: "esportes" },
           { text: "🧰 Ferramentas", link: "ferramentas" },
-          { text: "🌌 Trackers", link: "trackers" },
+          { text: "🧵 Trackers", link: "trackers" },
           { text: "🏴‍☠️ Warez", link: "warez" },
           { text: "☣️ Sites e Programas Inseguros", link: "sites-inseguros" },
           { text: "🚫 Adulto", link: "adulto" },

--- a/docs/anime.md
+++ b/docs/anime.md
@@ -15,7 +15,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 - 🌟 **Recomendações da Comunidade:** Links marcados com 🌟 são altamente recomendados pelos piratas veteranos.
 :::
 
-## 📑 1 ➜ Streaming
+## 📑 ➜ Streaming
 
 ### 🌟 [Better Anime](https://betteranime.net/)
 - **Better Anime** está com restrições de DMCA, mas funciona normalmente pelo app ou pelo site após login. Se não logar, ele não funcionará.
@@ -45,7 +45,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### ▶️ [Q1N](https://q1n.net/)
 - [Verificação de segurança da URL](https://www.urlvoid.com/scan/q1n.net/)
 
-## 📑 2 ➜ Downloads Diretos
+## 📑 ➜ Downloads Diretos
 
 ### 🌟 [Anitsu](https://anitsu.moe/#)
 - Grande catálogo, especialmente para animes obscuros com legenda PT-BR. **Use um media player de sua preferência no lugar do VLC.**
@@ -118,7 +118,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 - TachiyomiSY pretende avançar em termos de usabilidade e recursos, mas mantendo atualizações e recursos do aplicativo principal
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
 
-## 📑 3 ➜ Torrents
+## 📑 ➜ Torrents
 
 ### 🧲 [AniRena](https://www.anirena.com/)
 - Tracker simples para torrents de animes, dramas e músicas.
@@ -148,7 +148,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### 🧲 [UniOtaku](https://tracker.uniotaku.com/)
 - Tracker semi-privado.
 
-## 📑 4 ➜ No Telegram
+## 📑 ➜ No Telegram
 
 ### 🌟 [Algo Animes](https://t.me/algoanimes)
 - Mesmo criador do Algo Books.
@@ -157,7 +157,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 
 ### 🔗 [Central dos Animes](https://t.me/Centraldeanimes_Baltigo)
 
-## 📰 5 ➜ Legendas
+## 📰 ➜ Legendas
 
 ### 🔗 [AnimeDB](https://anidb.net/)
 - Base de dados internacional sobre animes e legendas.
@@ -165,7 +165,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### 🔗 [InfoAnime](https://www.infoanime.com.br/)
 - Acompanhamento de projetos de fansubers e scanlators brasileiros.
 
-## 🧰 6 ➜ Programas
+## 🧰 ➜ Programas
 
 ### 🔗 [GoAnime](https://github.com/alvarorichard/GoAnime)
 - Ferramenta CLI que baixa e reproduz animes em PT-BR (Dublado ou legendado).

--- a/docs/anime.md
+++ b/docs/anime.md
@@ -106,7 +106,7 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### 🧲 [UniOtaku](https://tracker.uniotaku.com/)
 - Tracker semi-privado.
 
-## 📑 4 ➜ Canais/Grupos no Telegram
+## 📑 4 ➜ No Telegram
 
 ### 🌟 [Algo Animes](https://t.me/algoanimes)
 - Mesmo criador do Algo Books.

--- a/docs/anime.md
+++ b/docs/anime.md
@@ -76,6 +76,48 @@ Anime é um estilo de animação originário do Japão, desenhado à mão ou por
 ### 🔗 [Tokyo Insider](https://www.tokyoinsider.com/)
 - [Verificação de segurança da URL](https://www.urlvoid.com/scan/tokyoinsider.com/)
 
+## 📑 ➜ Mobile
+
+### 🌟 [Mihon](https://github.com/mihonapp/mihon) 
+
+- Acesse facilmente mangás, webcomics e quadrinhos em seu dispositivo Android.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
+
+### 🌟 [Better Anime](https://discord.com/invite/betteranime) 
+
+- O famoso **Better Anime** que está com DMCA mas está funcionando normalmente pelo app ou pelo site logando com sua conta, se não logar ele não vai funcionar. App removido da playstore, disponível apenas no discord. 
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/discord.com/)
+
+### 🔗 [Tachimanga](https://tachimanga.app/)
+
+- Leitor de mangá para IOS. É preciso adicionar as fontes dentro do app, as melhores são mangadex e mangafire.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/tachimanga.app/)
+
+### 🔗 [Aniyomi](https://aniyomi.org/) 
+
+- Aniyomi é um fork não oficial do Tachiyomi que adiciona recursos de anime! Instalando as extensões ele vira o melhor app para assistir e baixar animes.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/aniyomi.org/)
+
+### 🔗 [Kuukiyomi](https://github.com/LuftVerbot/kuukiyomi) 
+
+- Fork do Aniyomi com a função de mangás restaurada e recursos extras.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
+
+### 🔗 [Animiru](https://github.com/Quickdesh/Animiru) 
+
+- Animiru é um fork não oficial do Aniyomi, que é mais um fork não oficial do leitor de mangá gratuito e de código aberto Tachiyomi.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
+
+### 🔗 [Kotatsu](https://kotatsu.app/) 
+
+- Um leitor de mangá de código aberto simples e conveniente para a comunidade, onde você pode encontrar e ler seu mangá favorito com mais facilidade do que nunca.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/kotatsu.app/)
+
+### 🔗 [TachiyomiSY](https://github.com/jobobby04/TachiyomiSY) 
+
+- TachiyomiSY pretende avançar em termos de usabilidade e recursos, mas mantendo atualizações e recursos do aplicativo principal
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
+
 ## 📑 3 ➜ Torrents
 
 ### 🧲 [AniRena](https://www.anirena.com/)

--- a/docs/educacional.md
+++ b/docs/educacional.md
@@ -133,7 +133,7 @@ A educação é o processo de adquirir conhecimento, habilidades e valores funda
 ### 🧲 [Docspedia](https://docspedia.world/signup.php) - Cursos / Inscrição Necessária
 
 ### 🧲 [Download Cursos Gratis](https://www.downloadcursos.org/) - Cursos nacionais  
-***Desative o JS, aperte F12 antes que o site carregue e exclua a linha que contém 'mdp-deblocker-js-disabled'***
+***Use o [PopUpOFF](https://popupoff.org/) e desative o JS***
 
 ### 🧲 [Online Free Course](https://www.onlinefreecourse.net/) - Cursos da Udemy
 

--- a/docs/educacional.md
+++ b/docs/educacional.md
@@ -159,7 +159,7 @@ A educação é o processo de adquirir conhecimento, habilidades e valores funda
 
 - Variedade de livros para kindle de maneira organizada.
 
-## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram
+## 📣 ➜ No Telegram
 
 ### 🔗 [Polemic Knowledge Clone](https://t.me/+-eUQNwLw9G5mNDUx)
 

--- a/docs/emuladores-roms.md
+++ b/docs/emuladores-roms.md
@@ -362,7 +362,7 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brazilalliance.com.br/)
 ### 🔗 [Tribo Gamer](https://tribogamer.com/traducoes/)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tribogamer.com/)
-### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [🔗](https://t.me/CentralDeTraducoes) 
+### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [📣](https://t.me/CentralDeTraducoes) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
 ### 🔗 [Fórum RHDNBR](https://www.romhacking.net.br/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/romhacking.net.br/)
@@ -379,7 +379,7 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 
 ### 🔗 [PT-BR Hud • SRB2](https://mb.srb2.org/addons/pt-br-hud-hud-brasileiro.5400/)
 
-- Sonic Robo Blast 2 é um fangame que vem sendo atualizado desde 1998. Este mod modesto aplica tradução somente no hub de pontos e tempo.
+- Sonic Robo Blast 2 é um fangame que vem sendo atualizado desde 1998. Este mod modesto aplica tradução somente no hud de pontos e tempo.
 
 ### 🔗 [Rippersanime](https://forum.rippersanime.info/viewforum.php?f=17)
 

--- a/docs/emuladores-roms.md
+++ b/docs/emuladores-roms.md
@@ -19,6 +19,12 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 
 - Lista incrível de emuladores que ainda estão ativos e atualizados regularmente.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/emulation.gametechwiki.com/)
+
+### 📒 [The Cutting Room Floor](https://tcrf.net/The_Cutting_Room_Floor)
+
+- Dedicado a desvendar e pesquisar conteúdo removido ou inutilizado de jogos antigos.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/tcrf.net/)
+  
 ---
 ## 📑 ➜ Emulação no Navegador
 

--- a/docs/emuladores-roms.md
+++ b/docs/emuladores-roms.md
@@ -20,7 +20,7 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - Lista incrível de emuladores que ainda estão ativos e atualizados regularmente.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/emulation.gametechwiki.com/)
 
-### 📒 [The Cutting Room Floor](https://tcrf.net/The_Cutting_Room_Floor)
+### 📒 [The Cutting Room Floor](https://tcrf.net/The_Cutting_Room_Floor/pt-br)
 
 - Dedicado a desvendar e pesquisar conteúdo removido ou inutilizado de jogos antigos.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tcrf.net/)

--- a/docs/emuladores-roms.md
+++ b/docs/emuladores-roms.md
@@ -356,7 +356,7 @@ Os emuladores simulam as ações dos consoles de jogos, enquanto as ROMs são c�
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brazilalliance.com.br/)
 ### 🔗 [Tribo Gamer](https://tribogamer.com/traducoes/)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tribogamer.com/)
-### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [![](public/images/telegram.png)](https://t.me/CentralDeTraducoes) 
+### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [🔗](https://t.me/CentralDeTraducoes) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
 ### 🔗 [Fórum RHDNBR](https://www.romhacking.net.br/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/romhacking.net.br/)

--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -300,8 +300,9 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - [Arquivos da Web](https://github.com/dessant/web-archives) - Arquivos da Web é uma extensão do navegador que permite encontrar versões arquivadas e em cache de páginas da Web (funciona em mais de 10 mecanismos de pesquisa).
 - [Stylus](https://github.com/openstyles/stylus) - Instale temas CSS modificados.
 - [I still don't care about cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies) - Livre-se de requests de cookies em qualquer site.
+- [Port Authority](https://github.com/ACK-J/Port_Authority/) - Protege contra ataques port scan.
 - [Auto Referer](https://github.com/garywill/autoReferer?tab=readme-ov-file) - Controla o que é mandado como HTTP Referer em cada site.
-- [Decentraleyes](https://git.synz.io/Synzvato/decentraleyes) - Te protege contra tracking.
+- [Decentraleyes](https://git.synz.io/Synzvato/decentraleyes) - Protege contra tracking.
 - [LocalCDN](https://www.localcdn.org/) - Redireciona requisições para as bibliotecas web mais comuns para uma versão armazenada localmente, reduzindo uso de dados e aumentando sua privacidade.
 
 ## ► Telegram

--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -181,6 +181,7 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 
 * [MKVToolNix](https://mkvtoolnix.download/downloads.html) - Gera o arquivo de vídeo em formato .mkv com uma ou várias faixas de legenda e áudio.
 * **[Pago]** [After Codecs](https://www.autokroma.com/AfterCodecs/Download#Changelog) - Plugin pra acrescentar a opção de converter vídeos para MP4 no After Effects
+* [SubtitleEdit](https://github.com/SubtitleEdit/subtitleedit/releases)
 
 ## ► Gerenciadores de download
 

--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -113,6 +113,7 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - [Botão Sci-hub](https://greasyfork.org/en/scripts/370246-sci-hub-button) - Adiciona um botão sci-hub a inúmeros sites de artigos acadêmicos/acadêmicos para desbloquear o artigo que está sendo visualizado.
 - [AdsBypasser](https://adsbypasser.github.io/) - Ignore anúncios de contagem regressiva ou continue páginas e evite janelas pop-up de anúncios.
 - [AntiAdware](https://github.com/HandyUserscripts/AntiAdware##readme) - Evite a instalação de download de aplicativos indesejados com software legítimo (por exemplo, McAfee com Adobe Flash).
+- [Youtube share url si parameter remover](https://greasyfork.org/en/scripts/474050-youtube-share-url-si-parameter-remover) - Retira o parâmetro de rastreamento do link de compartilhamento do Youtube.
 - [Newspaper-Paywall-Bypasser](https://greasyfork.org/en/scripts/18585-newspaper-paywall-bypasser) - Ignore os paywalls de sites de jornais. Requer tampermonkey/greasemonkey para instalar.
 - [Obter informações de DLC do SteamDB](https://github.com/Sak32009/GetDLCInfoFromSteamDB) - Cria automaticamente uma lista de DLC para ferramentas como CreamAPI, GreenLuma e SmartSteamEmu.
 - [Desbloqueie as etapas do Symbolabs e verifique as soluções](https://pastebin.com/wA3QQkCj) - Userscript: [archive](https://web.archive.org/web/20200818154537/https://pastebin.com/wA3QQkCj)
@@ -289,6 +290,20 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - [PowerToys](https://docs.microsoft.com/en-us/windows/powertoys/) - Permite renomear por RegEx
 - [Ant Renamer](https://antp.be/software/renamer) - Ótimo para gerenciamento rápido de strings em massa (para Plex, por exemplo).
 
+## ► **Extensões**
+
+:::warning Add-ons podem quebrar algumas páginas.
+:::
+
+- [NoScript](https://noscript.net/) - Bloqueia todos os scripts do site. Também protege contra ataques XSS.
+- [PopUpOFF](https://popupoff.org/) - Burla pop-ups e bloqueadores.
+- [Arquivos da Web](https://github.com/dessant/web-archives) - Arquivos da Web é uma extensão do navegador que permite encontrar versões arquivadas e em cache de páginas da Web (funciona em mais de 10 mecanismos de pesquisa).
+- [Stylus](https://github.com/openstyles/stylus) - Instale temas CSS modificados.
+- [I still don't care about cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies) - Livre-se de requests de cookies em qualquer site.
+- [Auto Referer](https://github.com/garywill/autoReferer?tab=readme-ov-file) - Controla o que é mandado como HTTP Referer em cada site.
+- [Decentraleyes](https://git.synz.io/Synzvato/decentraleyes) - Te protege contra tracking.
+- [LocalCDN](https://www.localcdn.org/) - Redireciona requisições para as bibliotecas web mais comuns para uma versão armazenada localmente, reduzindo uso de dados e aumentando sua privacidade.
+
 ## ► Telegram
 
 - [Vidsender](https://github.com/viniped/vidsender) - Método mais fácil para upar vários vídeos de uma vez só de forma organizada.
@@ -309,21 +324,6 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - 🧅 [Portlain](http://laingg42wznukvzjn52cos6bj6brgyiwtxf5rpq3bu5pad56volhe2qd.onion/portlain/)
 - 🧅 [Suprbay](http://suprbaydvdcaynfo4dgdzgxb4zuso7rftlil5yg5kqjefnw4wq4ulcad.onion/)
 - 🧅 [Autodefesa digital](http://tdtf5fdpfjgpxci4pqrtr5cvmsytqu25c2kdbflllz37k5glz6bexcyd.onion/)
-
-## ► **Extensões**
-
-:::warning Add-ons podem quebrar algumas páginas.
-:::
-
-- [NoScript](https://noscript.net/) - Bloqueia todos os scripts do site. Também protege contra ataques XSS.
-- [PopUpOFF](https://popupoff.org/) - Burla pop-ups e bloqueadores.
-- [Arquivos da Web](https://github.com/dessant/web-archives) - Arquivos da Web é uma extensão do navegador que permite encontrar versões arquivadas e em cache de páginas da Web (funciona em mais de 10 mecanismos de pesquisa).
-- [Stylus](https://github.com/openstyles/stylus) - Instale temas CSS modificados.
-- [I still don't care about cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies) - Livre-se de requests de cookies em qualquer site.
-- [ClearURLs](https://docs.clearurls.xyz/1.27.3/) - Modifica o trecho identificador de urls de sites como o youtube para evitar rastreamento.
-- [Auto Referer](https://github.com/garywill/autoReferer?tab=readme-ov-file) - Controla o que é mandado como HTTP Referer em cada site.
-- [Decentraleyes](https://git.synz.io/Synzvato/decentraleyes) - Te protege contra tracking.
-- [LocalCDN](https://www.localcdn.org/) - Redireciona requisições para as bibliotecas web mais comuns para uma versão armazenada localmente, reduzindo uso de dados e aumentando sua privacidade.
 
 ## ► **Motores de busca**
 - [Meawfy](https://meawfy.com/) - Um mecanismo de busca especializado em encontrar arquivos hospedados no Mega.nz.

--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -102,17 +102,17 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 
 - [Violentmonkey](https://violentmonkey.github.io/) - Gerenciador de script de usuário de código aberto.
 - [Tampermonkey](https://www.tampermonkey.net/) - Gerenciador de script de usuário de código aberto.
-- [greasyfork.org](https://greasyfork.org/) - Repo para incontáveis ​​userscripts úteis
+- [greasyfork.org](https://greasyfork.org/) - Repo para incontáveis ​​userscripts úteis.
 - [userscripts-mirror.org](https://userscripts-mirror.org/) - Repositório alternativo de scripts. Espelho para Userscripts.org.
-- [openuserjs.org](https://openuserjs.org/) - repositório alternativo de scripts
-- [musescore-downloader](https://github.com/Xmader/musescore-downloader) - Baixe partituras de musescore gratuitamente
-- [URL-Shortener-Unshortened](https://greasyfork.org/en/scripts/5359-url-shortener-unshortener) - Adiciona botão ao lado de URLs encurtados que resolve o URL para sua localização verdadeira
-- [anti-anti-copy](https://greasyfork.org/en/scripts/7197-anti-anti-copy) - Permite a cópia de texto de sites que tentam impedir a cópia
-- [absolute-enable-right-click-and-copy](https://greasyfork.org/en/scripts/23772-absolute-enable-right-click-copy) - Permite clicar com o botão direito e copiar em sites que tentam evitar clicar com o botão direito
-- [select-text-inside-a-link-like-opera](https://greasyfork.org/en/scripts/789-select-text-inside-a-link-like-opera) - Permite selecionar/realçar links em vez do comportamento padrão de arrastá-los
+- [openuserjs.org](https://openuserjs.org/) - repositório alternativo de scripts.
+- [musescore-downloader](https://github.com/Xmader/musescore-downloader) - Baixe partituras de musescore gratuitamente.
+- [URL-Shortener-Unshortened](https://greasyfork.org/en/scripts/5359-url-shortener-unshortener) - Adiciona botão ao lado de URLs encurtados que resolve o URL para sua localização verdadeira.
+- [anti-anti-copy](https://greasyfork.org/en/scripts/7197-anti-anti-copy) - Permite a cópia de texto de sites que tentam impedir a cópia.
+- [absolute-enable-right-click-and-copy](https://greasyfork.org/en/scripts/23772-absolute-enable-right-click-copy) - Permite clicar com o botão direito e copiar em sites que tentam evitar clicar com o botão direito, pode remover também proteções anti cópia para vídeos e imagens.
+- [select-text-inside-a-link-like-opera](https://greasyfork.org/en/scripts/789-select-text-inside-a-link-like-opera) - Permite selecionar/realçar links em vez do comportamento padrão de arrastá-los.
 - [Botão Sci-hub](https://greasyfork.org/en/scripts/370246-sci-hub-button) - Adiciona um botão sci-hub a inúmeros sites de artigos acadêmicos/acadêmicos para desbloquear o artigo que está sendo visualizado.
 - [AdsBypasser](https://adsbypasser.github.io/) - Ignore anúncios de contagem regressiva ou continue páginas e evite janelas pop-up de anúncios.
-- [AntiAdware](https://github.com/HandyUserscripts/AntiAdware##readme) - Evite a instalação de download de aplicativos indesejados com software legítimo (por exemplo, McAfee com Adobe Flash)
+- [AntiAdware](https://github.com/HandyUserscripts/AntiAdware##readme) - Evite a instalação de download de aplicativos indesejados com software legítimo (por exemplo, McAfee com Adobe Flash).
 - [Newspaper-Paywall-Bypasser](https://greasyfork.org/en/scripts/18585-newspaper-paywall-bypasser) - Ignore os paywalls de sites de jornais. Requer tampermonkey/greasemonkey para instalar.
 - [Obter informações de DLC do SteamDB](https://github.com/Sak32009/GetDLCInfoFromSteamDB) - Cria automaticamente uma lista de DLC para ferramentas como CreamAPI, GreenLuma e SmartSteamEmu.
 - [Desbloqueie as etapas do Symbolabs e verifique as soluções](https://pastebin.com/wA3QQkCj) - Userscript: [archive](https://web.archive.org/web/20200818154537/https://pastebin.com/wA3QQkCj)
@@ -226,19 +226,23 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 * 🌟 [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Ferramenta de linha de comando de código aberto para baixar vídeo/áudio de uma grande variedade de sites. Veja o [FAQ](https://github.com/yt-dlp/yt-dlp/wiki/FAQ) para saber como instalar e usar corretamente. 
 * [yt-dlp-gui](https://github.com/dsymbol/yt-dlp-gui) - Um wrapper GUI multiplataforma para yt-dlp escrito em PySide6.
 * [CocoCut](https://cococut.net/locales/pt-br/) - Suporta o download de arquivos em diferentes formatos.
+* [Allvasoft](https://www.allavsoft.com/) 
 * [Local Youtube Downloader](https://greasyfork.org/en/scripts/369400-local-youtube-downloader) - Userscript para baixar vídeos do youtube
 * [Youtube Subtitle Downloader](https://greasyfork.org/en/scripts/5368-youtube-subtitle-downloader-v20) - Userscript para baixar legendas do youtube
 * [UWPDumper](https://github.com/Wunkolo/UWPDumper) - DLL e Injetor para despejar aplicativos UWP.
 * [gallery-dl](https://github.com/mikf/gallery-dl) - gallery-dl é um programa de linha de comando para baixar galerias e coleções de imagens de vários sites de hospedagem de imagens.
 * **[Pago]** [After Codecs](https://www.autokroma.com/AfterCodecs/Download#Changelog) - Plugin pra acrescentar a opção de converter vídeos para MP4 no After Effects
+* [Fetchv](https://fetchv.net/pt-br) 
+* [MKVToolNix](https://mkvtoolnix.download/downloads.html) - Gera o arquivo de vídeo em formato .mkv com uma ou várias faixas de legenda e áudio.
 * [Anime-Downloader](https://github.com/Oshan96/Anime-Downloader) - Download em massa de episódios de anime para vários sites, em várias resoluções, com ou sem episódios de preenchimento.
 * [bandcamp-dl](https://github.com/iheanyi/bandcamp-dl) - Baixe músicas do Bandcamp.
-* [Video DownloadHelper](https://www.downloadhelper.net/) - Basta fixar a extensão e dar play no vídeo que ela identifica e oferece várias opções de qualidade para download. Também cobre vários sites além do YouTube.
+* [Video DownloadHelper](https://www.downloadhelper.net/) - Basta fixar a extensão e dar play no vídeo que ela identifica e oferece várias opções de qualidade para download.
 * [Video Downloader Professional](https://chromewebstore.google.com/detail/video-downloader-professi/elicpjhcidhpjomhibiffojpinpmmpil?hl=en) - Essa extensão para o Google Chrome permite baixar vídeos de várias plataformas.
 * **[Pago]** [StreamFab](https://streamfab.com/) - Focado em download para plataformas de streaming.
 * [Megabasterd](https://github.com/tonikelope/megabasterd) - Ignore o limite de download de 5 GiB por 6 horas do Mega.
 * [Skillshare-dl](https://github.com/mrwnwttk/skillshare-dl) - Baixe do skillshare. [Tópico original.](https://www.reddit.com/r/Piracy/comments/dn16jp/skillsharedl_now_with_windows_support/)
 * [Outro Skillshare-dl](https://github.com/KENWAY/Skillshare-DL) - Baixe do skillshare
+* [Firedown](https://www.firedown.app/)
 * [Baixar do Soundcloud](https://addons.mozilla.org/en-US/firefox/addon/soundcloud-dl/) - Extensão do Firefox. Tópico original [aqui](https://addons.mozilla.org/en-US/firefox/addon/soundcloud-dl/). Por /u/ImTwain.
 * **[Pago]** [Katomart](https://katomart.com/) - Aplicativo em fase de testes que faz o download de vídeos de plataformas EAD, tudo dentro da lei.
 * [Omnibus](https://github.com/fireshaper/Omnibus) - Faça o download de GetComics.info facilmente
@@ -303,19 +307,18 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - 🧅 [Suprbay](http://suprbaydvdcaynfo4dgdzgxb4zuso7rftlil5yg5kqjefnw4wq4ulcad.onion/)
 - 🧅 [Autodefesa digital](http://tdtf5fdpfjgpxci4pqrtr5cvmsytqu25c2kdbflllz37k5glz6bexcyd.onion/)
 
-## ► **Outras extensões para navegador**
+## ► **Extensões**
 
 :::warning Add-ons podem quebrar algumas páginas.
 :::
 
 - [NoScript](https://noscript.net/) - Bloqueia todos os scripts do site. Também protege contra ataques XSS.
-- [Allow Right Click](https://github.com/lunu-bounir/allow-right-click/) - Força o clique com o botão de direito, o que traz de volta a opção de inspecionar em sites que bloqueiam as ferramentas de desenvolvedor.
+- [PopUpOFF](https://popupoff.org/) - Burla pop-ups e bloqueadores.
 - [Arquivos da Web](https://github.com/dessant/web-archives) - Arquivos da Web é uma extensão do navegador que permite encontrar versões arquivadas e em cache de páginas da Web (funciona em mais de 10 mecanismos de pesquisa).
 - [Stylus](https://github.com/openstyles/stylus) - Instale temas CSS modificados.
 - [I still don't care about cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies) - Livre-se de requests de cookies em qualquer site.
-- [CleanURLs](https://docs.clearurls.xyz/1.27.3/) - Modifica o trecho identificador de urls de sites como o youtube para evitar rastreamento.
+- [ClearURLs](https://docs.clearurls.xyz/1.27.3/) - Modifica o trecho identificador de urls de sites como o youtube para evitar rastreamento.
 - [Auto Referer](https://github.com/garywill/autoReferer?tab=readme-ov-file) - Controla o que é mandado como HTTP Referer em cada site.
-- [Cookie AutoDelete](https://github.com/Cookie-AutoDelete/Cookie-AutoDelete) - Deleta cookies automaticamente.
 - [Decentraleyes](https://git.synz.io/Synzvato/decentraleyes) - Te protege contra tracking.
 - [LocalCDN](https://www.localcdn.org/) - Redireciona requisições para as bibliotecas web mais comuns para uma versão armazenada localmente, reduzindo uso de dados e aumentando sua privacidade.
 

--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -176,6 +176,11 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - [SickChill](https://sickchill.github.io/) - Muito boa alternativa ao Sonarr. Uma ferramenta automática de download de programas de TV.
 - [Lidarr](https://lidarr.audio/) - Um Radarr para álbuns musicais.
 
+## ► Ferramentas de mídia
+
+* [MKVToolNix](https://mkvtoolnix.download/downloads.html) - Gera o arquivo de vídeo em formato .mkv com uma ou várias faixas de legenda e áudio.
+* **[Pago]** [After Codecs](https://www.autokroma.com/AfterCodecs/Download#Changelog) - Plugin pra acrescentar a opção de converter vídeos para MP4 no After Effects
+
 ## ► Gerenciadores de download
 
 > São úteis para sites DDL. Gerenciadores de download como esses destinam-se a ajudar a acelerar os downloads, geralmente aumentando o número de conexões com o servidor ou tentando dividir o download em partes. Eles também são especialmente úteis ao obter vários links de uma só vez, o que é típico de sites DDL, onde eles dividem grandes downloads em várias pequenas partes `.rar`, além de ignorar captchas e eliminar os riscos de clicar no link errado botão de download em vários hosts de arquivo. Eles também ajudam a retomar downloads pausados ​​ou expirados que seu navegador pode não ser capaz de fazer em alguns casos.
@@ -215,7 +220,7 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 - [Cnvmp3](https://cnvmp3.com/) - Converta vídeos do YouTube para MP3 ou MP4 e baixe-os com este conversor rápido e gratuito do YouTube. O CnvMP3 é livre de anúncios, seguro e suporta qualidade de até 320 kbps.
 - [Ezmp3](https://ezmp3.co/) - EzMP3 é o conversor de YouTube para MP3 sem anúncios que permite converter vídeos de até 12 horas de duração. Você pode cortar o áudio e escolher uma taxa de bits de 64 kbps a 320 kbps.
 
-## ► Outras ferramentas de download/mídia
+## ► Outras ferramentas de download
 
 * [ytDownloader](https://github.com/aandrew-me/ytDownloader) - Um aplicativo GUI moderno para baixar vídeos e áudios de centenas de sites
 * [Hitomi Downloader](https://github.com/KurtBestor/Hitomi-Downloader) - Ferramenta para baixar imagens/vídeos/música/texto de vários sites e muito mais.
@@ -226,14 +231,12 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 * 🌟 [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) - Ferramenta de linha de comando de código aberto para baixar vídeo/áudio de uma grande variedade de sites. Veja o [FAQ](https://github.com/yt-dlp/yt-dlp/wiki/FAQ) para saber como instalar e usar corretamente. 
 * [yt-dlp-gui](https://github.com/dsymbol/yt-dlp-gui) - Um wrapper GUI multiplataforma para yt-dlp escrito em PySide6.
 * [CocoCut](https://cococut.net/locales/pt-br/) - Suporta o download de arquivos em diferentes formatos.
-* [Allvasoft](https://www.allavsoft.com/) 
+* [Allvasoft](https://www.allavsoft.com/) - Downloader de vídeos.
 * [Local Youtube Downloader](https://greasyfork.org/en/scripts/369400-local-youtube-downloader) - Userscript para baixar vídeos do youtube
 * [Youtube Subtitle Downloader](https://greasyfork.org/en/scripts/5368-youtube-subtitle-downloader-v20) - Userscript para baixar legendas do youtube
 * [UWPDumper](https://github.com/Wunkolo/UWPDumper) - DLL e Injetor para despejar aplicativos UWP.
 * [gallery-dl](https://github.com/mikf/gallery-dl) - gallery-dl é um programa de linha de comando para baixar galerias e coleções de imagens de vários sites de hospedagem de imagens.
-* **[Pago]** [After Codecs](https://www.autokroma.com/AfterCodecs/Download#Changelog) - Plugin pra acrescentar a opção de converter vídeos para MP4 no After Effects
-* [Fetchv](https://fetchv.net/pt-br) 
-* [MKVToolNix](https://mkvtoolnix.download/downloads.html) - Gera o arquivo de vídeo em formato .mkv com uma ou várias faixas de legenda e áudio.
+* [Fetchv](https://fetchv.net/pt-br) - Downloader de vídeos
 * [Anime-Downloader](https://github.com/Oshan96/Anime-Downloader) - Download em massa de episódios de anime para vários sites, em várias resoluções, com ou sem episódios de preenchimento.
 * [bandcamp-dl](https://github.com/iheanyi/bandcamp-dl) - Baixe músicas do Bandcamp.
 * [Video DownloadHelper](https://www.downloadhelper.net/) - Basta fixar a extensão e dar play no vídeo que ela identifica e oferece várias opções de qualidade para download.
@@ -242,7 +245,7 @@ Estes são sites que rastreiam os lançamentos do Scene. Eles servem estritament
 * [Megabasterd](https://github.com/tonikelope/megabasterd) - Ignore o limite de download de 5 GiB por 6 horas do Mega.
 * [Skillshare-dl](https://github.com/mrwnwttk/skillshare-dl) - Baixe do skillshare. [Tópico original.](https://www.reddit.com/r/Piracy/comments/dn16jp/skillsharedl_now_with_windows_support/)
 * [Outro Skillshare-dl](https://github.com/KENWAY/Skillshare-DL) - Baixe do skillshare
-* [Firedown](https://www.firedown.app/)
+* [Firedown](https://www.firedown.app/) - Downloader de vídeos.
 * [Baixar do Soundcloud](https://addons.mozilla.org/en-US/firefox/addon/soundcloud-dl/) - Extensão do Firefox. Tópico original [aqui](https://addons.mozilla.org/en-US/firefox/addon/soundcloud-dl/). Por /u/ImTwain.
 * **[Pago]** [Katomart](https://katomart.com/) - Aplicativo em fase de testes que faz o download de vídeos de plataformas EAD, tudo dentro da lei.
 * [Omnibus](https://github.com/fireshaper/Omnibus) - Faça o download de GetComics.info facilmente
@@ -370,6 +373,7 @@ São VPNS que usam o protocolo SSH para transmitir uma conexão de franquia de d
 #### ► **Launchers de jogos**
 
 - [Legacy Launcher](https://llaun.ch/pt-br)- Launcher seguro para Minecraft, ao contrário do TLauncher
+- [Prism Launcher Cracked](https://github.com/Diegiwg/PrismLauncher-Cracked?tab=readme-ov-file) - Desbloqueia o uso de contas offline no Minecraft
 - [Playnite](https://playnite.link/) - Launcher universal de jogos para Windows
 - [GOG Galaxy](https://www.gog.com/galaxy) - Launcher universal de jogos para Windows/MacOS
 - [Lutris](https://lutris.net/) - Launcher universal de jogos para Linux

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -229,7 +229,7 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/podnapisi.net/) 
 
 
-## ![](https://files.catbox.moe/7ad7g5.png) No Telegram  
+## 📑 No Telegram  
 ### 🌟 [Polemic Filmes](https://t.me/polemicfilmes) 
 ### [Cadê o Filme 7.0](https://t.me/+3j6I2jzuik1hMjgx)  
 

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -50,6 +50,10 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - Uma infinidade de filmes, séries e animes. Aceita legenda que vc baixou de outros sites.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/freek.to/) 
 
+### 🌟 [HydraHD](https://hydrahd.me/)
+- Sem precisar se inscrever, aproveite filmes e séries gratuitos em streaming na maior biblioteca.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/hydrahd.me/)
+
 ### 🌟 [Cinema Deck](https://cinemadeck.com/)
 - Mergulhe em um mundo de entretenimento ilimitado com milhares de filmes e programas de TV abrangendo vários gêneros.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/cinemadeck.com/) 
@@ -57,10 +61,6 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 ### 🌟 [CorsFlix](https://corsflix.us.kg/)
 - Entretenimento sem fim na ponta dos seus dedos, com acesso instantâneo aos últimos lançamentos.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/corsflix.us.kg/) 
-
-### 🌟 [HydraHD](https://hydrahd.me/)
-- Sem precisar se inscrever, aproveite filmes e séries gratuitos em streaming na maior biblioteca.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/hydrahd.me/) 
 
 ### 🌟 [Novafork](https://novafork.cc/)
 - Atendendo a todos os gostos, a variedade de filmes inclui desde clássicos até sucessos de bilheteria.

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -36,11 +36,14 @@ Apesar dessas ferramentas não estarem diretamente ligadas à pirataria, são de
 * [Pi](https://pi.ai/talk) - Chatbot IA com emoções
 * [FreedomGPT](https://chat.freedomgpt.com/pt) - Chatbot sem censura
 * [Napkin AI](https://www.napkin.ai/) - Cria fluxogramas
+* [Legen](https://matheusbach.github.io/legen/) - Embute legendas em vídeos
+
 ***
 ### Simulação
 
 * 🌐 [Ayumi LLM](http://ayumi.m8geil.de/ayumi_bench_v3_results.html) ou [BestERP](https://besterp.ai/) - Listas de LLM para simulação
 * 🌐 [Img-Resources](https://rentry.org/lmg-resources) - Recursos de Personagens / [Templates](https://rentry.org/lmg_template)
+* ⭐ [SillyTavern](https://sillytavernai.com/) - Chatbots de Simulação
 * [PygmalionAI](https://discord.com/invite/pygmalionai) - Modelos de Simulação Auto-hospedados com recursos / [Resources](https://rentry.co/PygmalionLinks)
 * [Call Annie](https://callannie.ai/) - GPT-3.5 Chatbot com video e voz em tempo real 
 * [Character AI](https://character.ai/) - Chatbots de Simulação / [Extract Params](https://rentry.org/reverseCAI)

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -149,6 +149,7 @@ Apesar dessas ferramentas não estarem diretamente ligadas à pirataria, são de
 ***
 ### Vídeo
 
+* [VEO](https://deepmind.google/models/veo/) - Gerador de Vídeos
 * [PixVerse](https://pixverse.ai/) - Gerador de Vídeos
 * [Synthesis Colab](https://github.com/camenduru/text-to-video-synthesis-colab) - Gerador de Vídeos
 * [StableVideo](https://www.stablevideo.com/) - Gerador de Vídeos

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -94,7 +94,7 @@ Apesar dessas ferramentas não estarem diretamente ligadas à pirataria, são de
 * [OpenDevin](https://github.com/OpenDevin/OpenDevin) - Gerador de código
 * [Bito AI](https://bito.ai/) - Code Review
 * [Claude Dev](https://github.com/saoudrizwan/claude-dev) - Gerador de código
-
+* [Roo Code](https://roocode.com/) - Gerador de código
 
 ## 📝 Manipuladores de Texto
 

--- a/docs/ia.md
+++ b/docs/ia.md
@@ -43,7 +43,7 @@ Apesar dessas ferramentas não estarem diretamente ligadas à pirataria, são de
 
 * 🌐 [Ayumi LLM](http://ayumi.m8geil.de/ayumi_bench_v3_results.html) ou [BestERP](https://besterp.ai/) - Listas de LLM para simulação
 * 🌐 [Img-Resources](https://rentry.org/lmg-resources) - Recursos de Personagens / [Templates](https://rentry.org/lmg_template)
-* ⭐ [SillyTavern](https://sillytavernai.com/) - Chatbots de Simulação
+* ⭐ [SillyTavern](https://sillytavernai.com/) - Frontend com chatbots de simulação
 * [PygmalionAI](https://discord.com/invite/pygmalionai) - Modelos de Simulação Auto-hospedados com recursos / [Resources](https://rentry.co/PygmalionLinks)
 * [Call Annie](https://callannie.ai/) - GPT-3.5 Chatbot com video e voz em tempo real 
 * [Character AI](https://character.ai/) - Chatbots de Simulação / [Extract Params](https://rentry.org/reverseCAI)

--- a/docs/jogos.md
+++ b/docs/jogos.md
@@ -206,6 +206,10 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 ### 🚀 [Legacy Launcher](https://llaun.ch/pt-BR) 
 
 - Launcher seguro para Minecraft, ao contrário do TLauncher
+ 
+### 🚀 [Prism Launcher Cracked](https://github.com/Diegiwg/PrismLauncher-Cracked?tab=readme-ov-file) 
+
+- Desbloqueia o uso de contas offline no Minecraft
 
 ### 🚀 [Playnite](https://playnite.link/) 
 

--- a/docs/jogos.md
+++ b/docs/jogos.md
@@ -23,7 +23,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brazilalliance.com.br/)
 ### 🔗 [Tribo Gamer](https://tribogamer.com/traducoes/)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tribogamer.com/)
-### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [🔗](https://t.me/CentralDeTraducoes) 
+### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [📣](https://t.me/CentralDeTraducoes) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
 ### 🔗 [Fórum RHDNBR](https://www.romhacking.net.br/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/romhacking.net.br/)
@@ -304,7 +304,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - O Steam Verde é uma plataforma online de jogos para PC e Android, oferecendo downloads via torrent com uma interface organizada. Conta com uma comunidade ativa que fornece tutoriais e suporte, além de manter os usuários informados sobre lançamentos. O site possui proteção antivírus e é baseado na plataforma segura Invision Community.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/steamverde.net)
 
-### 🧲 [online-fix](https://online-fix.me/) [🔗](https://t.me/s/onlinefix)
+### 🧲 [online-fix](https://online-fix.me/) [📣](https://t.me/s/onlinefix)
 
 - Jogue jogos online pirata com seus amigos, de forma gratuita com suporte de convite via Steam.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/online-fix.me/)

--- a/docs/jogos.md
+++ b/docs/jogos.md
@@ -23,7 +23,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brazilalliance.com.br/)
 ### 🔗 [Tribo Gamer](https://tribogamer.com/traducoes/)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/tribogamer.com/)
-### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/CentralDeTraducoes) 
+### 🔗 [Central de Traduções](https://www.centraldetraducoes.net.br/) [🔗](https://t.me/CentralDeTraducoes) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/centraldetraducoes.net.br/)
 ### 🔗 [Fórum RHDNBR](https://www.romhacking.net.br/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/romhacking.net.br/)
@@ -300,7 +300,7 @@ Esses são alguns site para encontrar tradução PT-BR para seus jogos:
 - O Steam Verde é uma plataforma online de jogos para PC e Android, oferecendo downloads via torrent com uma interface organizada. Conta com uma comunidade ativa que fornece tutoriais e suporte, além de manter os usuários informados sobre lançamentos. O site possui proteção antivírus e é baseado na plataforma segura Invision Community.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/steamverde.net)
 
-### 🧲 [online-fix](https://online-fix.me/) [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/s/onlinefix)
+### 🧲 [online-fix](https://online-fix.me/) [🔗](https://t.me/s/onlinefix)
 
 - Jogue jogos online pirata com seus amigos, de forma gratuita com suporte de convite via Steam.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/online-fix.me/)

--- a/docs/livros.md
+++ b/docs/livros.md
@@ -55,7 +55,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Esforço de compartilhamento de arquivos para artigos de periódicos acadêmicos, textos acadêmicos e livros de interesse geral.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/z-library.sk/) 
 
-## 📑➜ Leitura no navegador 
+## 📑 ➜ Leitura no navegador 
 ### 🔗 [Darkseid Club](https://site.ds-club.net/)     
 - O Darkseid Club é um grupo formado por fãs da nona arte e em especial pelo universo da editora DC Comic 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/site.ds-club.net/) 
@@ -72,7 +72,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 ### 🔗 [DeDRM tools](https://github.com/apprenticeharper/DeDRM_tools) (Multiplataforma) 
 - Plugin para o Calibre para remover DRM de livros comprados na Amazon ou Google Books. 
 
-## 📑➜ Mangá 
+## 📑 ➜ Mangá 
 ### 🌸 [SlimeRead](https://slimeread.com/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/slimeread.com/)  
 ### 🌸 [Ler Mangás](https://lermangas.me/) 
@@ -131,7 +131,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - O portal oferece uma grande seleção de quadrinhos mangá para todos os leitores e um layout amigável e simples de navegar. (Só aplicar o Filtro para Português BR)
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/mangafire.to/) 
 
-## 📑➜ Buscadores 
+## 📑 ➜ Buscadores 
 ### 🌟 [Arquivo da Anna](https://pt.annas-archive.org/) 
 - Library Genesis, Sci-Hub e Z-Library estão entre os sites incluídos neste resiliente mecanismo de pesquisa de bibliotecas de sombra.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/annas-archive.org/) 
@@ -142,7 +142,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Os usuários são ajudados pelo mecanismo de pesquisa a encontrar downloads gratuitos de e-books. Ele também permite alternar para uma função de pesquisa de Audiobook.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/ravebooksearch.com/) 
 
-## 📑➜ Streaming 
+## 📑 ➜ Streaming 
 ➜ Os sites abaixo são gringos e apenas oferecem conteúdos em inglês
 ➜ Caso você conheça algum site de livros e audiobooks em português, mande ele [aqui](https://lemmy.dbzer0.com/post/5116448). 
 ### ▶️ [LibriVox](https://librivox.org/) 
@@ -158,7 +158,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Histórias de áudio feitas para crianças. Relaxe e deixe a imaginação dos seus filhos vagar por reinos fantásticos.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/storynory.com/) 
 
-## 📑➜ Torrents 
+## 📑 ➜ Torrents 
 ### 🧲 [Academic Torrents](https://academictorrents.com/) 
 - Enormes conjuntos de dados compartilhados por meio de um sistema distribuído, dando aos pesquisadores acesso a um repositório de dados escalável, seguro e tolerante a falhas.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/academictorrents.com/) 
@@ -172,7 +172,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Para obter um convite, [veja esta página](https://www.myanonamouse.net/inviteapp.php) para mais detalhes.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/myanonamouse.net/) 
 
-## 📑➜ Sites de Audiolivros
+## 📑 ➜ Sites de Audiolivros
 ### ▶️ [AppAudioBooks](https://appaudiobooks.com/) 
 - Design fácil de usar que facilita a localização do audiolivro que você deseja ouvir.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/appaudiobooks.com/) 
@@ -201,7 +201,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Você pode desfrutar de todos os seus audiolivros favoritos gratuitamente online. Basta clicar para ouvir!
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/hotaudiobooks.com/) 
 
-## 📑➜ Fontes 
+## 📑 ➜ Fontes 
 ### 🌟 [FontsHub](https://fontshub.pro/) 
 - Obtenha fontes para criar títulos, citações, parágrafos, listas e outros componentes de texto para seus projetos de design.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/fontshub.pro/) 
@@ -257,7 +257,7 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Um utilitário da Web que obtém um URL de uma biblioteca Adobe Font e extrai a fonte do banco de dados.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/badnoise.net/)
 
-## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram 
+## 📑 ➜ No Telegram 
 ### 🤖 [Lestrad - Bibliotecário](https://t.me/lestrad_repost_bot)
 ### 🔗 [Banca BR](https://t.me/BancaBR)
 ### 🔗 [ITSBooks](https://t.me/ITSBooks)

--- a/docs/livros.md
+++ b/docs/livros.md
@@ -55,11 +55,16 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 - Esforço de compartilhamento de arquivos para artigos de periódicos acadêmicos, textos acadêmicos e livros de interesse geral.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/z-library.sk/) 
 
-## 📑 ➜ Leitura no navegador 
+## 📑 ➜ Quadrinhos 
+
 ### 🔗 [Darkseid Club](https://site.ds-club.net/)     
 - O Darkseid Club é um grupo formado por fãs da nona arte e em especial pelo universo da editora DC Comic 
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/site.ds-club.net/) 
----
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/site.ds-club.net/)
+
+### 🔗 [HQ Now](https://www.hq-now.com/)
+- Scan de revistas populares e clássicas.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/hq-now.com/)
+
 ## 📑➜ Aplicativos para Computador 
 ### 🔗 [HakuNeko](https://hakuneko.download/) 
 - O downloader de mangá e anime multiplataforma permite que você salve material para uso offline de uma variedade de sites.

--- a/docs/livros.md
+++ b/docs/livros.md
@@ -14,8 +14,6 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 :::
 
 ## 📑 ➜ Downloads diretos 
-### 🔗 [Baixar Quadrinhos](https://baixarquadrinhos.net) 
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/baixarquadrinhos.net/) 
 ### 🔗 [elivros](https://elivros.love/) 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/elivros.love/) 
 ### 🔗 [Baixe Livros](https://www.baixelivros.com.br/) 
@@ -64,6 +62,9 @@ Livros, como mangás, quadrinhos e romances, são um meio de registro de informa
 ### 🔗 [HQ Now](https://www.hq-now.com/)
 - Scan de revistas populares e clássicas.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/hq-now.com/)
+
+### 🔗 [Baixar Quadrinhos](https://baixarquadrinhos.net) 
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/baixarquadrinhos.net/)
 
 ## 📑➜ Aplicativos para Computador 
 ### 🔗 [HakuNeko](https://hakuneko.download/) 

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -513,7 +513,7 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 
 ## 📑 ➜ Filmes e TV
 
-### 🌟 [Stremio](https://www.stremio.com/) + [Addon de dublagem PT-BR](https://27a5b2bfe3c0-stremio-brazilian-addon.baby-beamup.club/) - [Nota Importante!](https://rentry.co/_stremio) 
+### 🌟 [Stremio](https://www.stremio.com/) + [Add-on de dublagem PT-BR](https://27a5b2bfe3c0-stremio-brazilian-addon.baby-beamup.club/) - [Nota Importante!](https://rentry.co/_stremio) 
 
 - Aplicativo de streaming que permite assistir vídeos, filmes e séries de TV.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/play.google.com/)

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -440,7 +440,7 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 - App para instalar Spotify sem anúncios.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/xmanagerapp.com/)
 
-## ![](https://files.catbox.moe/7ad7g5.png) ➜ No Telegram
+## 📑 ➜ No Telegram
 
 ### 🔗 [AlveeMods](https://t.me/AlveeMods) 
 - Apks modificados

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -462,6 +462,10 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 
 ## 📑 ➜ Anime e Manga
 
+:::info ℹ️ Dica sobre extensões
+    - Planilha no Docs com informações das extensões para ser usado em apps como Aniyomi, Tachiyomi, Dantotsu e etc. [Link](https://docs.google.com/spreadsheets/d/1Hc0hsUK1uNlh8zI0bAvFHzvbWt-RTKcBox4KxAZ9Z8c/edit?usp=drive_link)
+:::
+
 ### 🌟 [Mihon](https://github.com/mihonapp/mihon) 
 
 - Acesse facilmente mangás, webcomics e quadrinhos em seu dispositivo Android.
@@ -506,10 +510,6 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 
 - TachiyomiSY pretende avançar em termos de usabilidade e recursos, mas mantendo atualizações e recursos do aplicativo principal
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
-- 
-:::info ℹ️ Dica sobre extensões
-    - Planilha no Docs com informações das extensões para ser usado em apps como Aniyomi, Tachiyomi, Dantotsu e etc. [Link](https://docs.google.com/spreadsheets/d/1Hc0hsUK1uNlh8zI0bAvFHzvbWt-RTKcBox4KxAZ9Z8c/edit?usp=drive_link)
-:::
 
 ## 📑 ➜ Filmes e TV
 

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -71,43 +71,6 @@ Mobile, ou smartphones, são dispositivos portáteis que integram a funcionalida
 
 - Executa apps em alguns modelos de IOS sem lidar com restrições de assinatura de código.
 
-## 📑 ➜ Anime e Manga
-
-### 🌟 [Mihon](https://github.com/mihonapp/mihon) 
-
-- Acesse facilmente mangás, webcomics e quadrinhos em seu dispositivo Android.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
-
-### 🌟 [Better Anime](https://discord.com/invite/betteranime) 
-
-- O famoso **Better Anime** que está com DMCA mas está funcionando normalmente pelo app ou pelo site logando com sua conta, se não logar ele não vai funcionar. App removido da playstore, disponível apenas no discord. 
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/discord.com/)
-
-### 🔗 [Aniyomi](https://aniyomi.org/) 
-
-- Aniyomi é um fork não oficial do Tachiyomi que adiciona recursos de anime! Instalando as extensões ele vira o melhor app para assistir e baixar animes.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/aniyomi.org/)
-
-### 🔗 [Kuukiyomi](https://github.com/LuftVerbot/kuukiyomi) 
-
-- Fork do Aniyomi com a função de mangás restaurada e recursos extras.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
-
-### 🔗 [Animiru](https://github.com/Quickdesh/Animiru) 
-
-- Animiru é um fork não oficial do Aniyomi, que é mais um fork não oficial do leitor de mangá gratuito e de código aberto Tachiyomi.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
-
-### 🔗 [Kotatsu](https://kotatsu.app/) 
-
-- Um leitor de mangá de código aberto simples e conveniente para a comunidade, onde você pode encontrar e ler seu mangá favorito com mais facilidade do que nunca.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/kotatsu.app/)
-
-### 🔗 [TachiyomiSY](https://github.com/jobobby04/TachiyomiSY) 
-
-- TachiyomiSY pretende avançar em termos de usabilidade e recursos, mas mantendo atualizações e recursos do aplicativo principal
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/github.com/)
-
 ## 📑 ➜ Catálogo e Lojas
 
 ### 🔗 [Accrescent](https://accrescent.app/)

--- a/docs/sites-geral.md
+++ b/docs/sites-geral.md
@@ -57,15 +57,15 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 
 ## 📑 ➜ Telegram
 
-### 🔗 [Pirataria](https://t.me/trackerslist)
+### 📣 [Pirataria](https://t.me/trackerslist)
 
 - Participe do nosso canal oficial!
 
-### 🔗 [CopyrightBR](https://t.me/CopyrightBR)
+### 📣 [CopyrightBR](https://t.me/CopyrightBR)
 
 - Criado com o intuito de compartilhar notícias e releases da cena pirata brasileira. Contém avisos sobre warez/trackers abertos e muito mais.
 
-### 🔗 [UnCopy Group](https://t.me/UnCopyGroup)
+### 📣 [UnCopy Group](https://t.me/UnCopyGroup)
 
 - Grupo para quem busca material e papo de qualidade sobre p2p e a scene no geral.
 

--- a/docs/sites-geral.md
+++ b/docs/sites-geral.md
@@ -57,15 +57,15 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 
 ## 📑 ➜ Telegram
 
-### ![](https://files.catbox.moe/7ad7g5.png) [Pirataria](https://t.me/trackerslist)
+### 🔗 [Pirataria](https://t.me/trackerslist)
 
 - Participe do nosso canal oficial!
 
-### ![](https://files.catbox.moe/7ad7g5.png) [CopyrightBR](https://t.me/CopyrightBR)
+### 🔗 [CopyrightBR](https://t.me/CopyrightBR)
 
 - Criado com o intuito de compartilhar notícias e releases da cena pirata brasileira. Contém avisos sobre warez/trackers abertos e muito mais.
 
-### ![](https://files.catbox.moe/7ad7g5.png) [UnCopy Group](https://t.me/UnCopyGroup)
+### 🔗 [UnCopy Group](https://t.me/UnCopyGroup)
 
 - Grupo para quem busca material e papo de qualidade sobre p2p e a scene no geral.
 

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -117,7 +117,7 @@ Software é uma coleção de programas de computador junto com arquivos de supor
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/ravesoftwaresearch.pages.dev/) 
 ---
 ## 📑 4 ➜ Torrents 
-### 🌟 [M0nkrus](https://w16.monkrus.ws/) | [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/m0nkrus/) • Interface em russo 
+### 🌟 [M0nkrus](https://w16.monkrus.ws/) | [📣](https://t.me/m0nkrus/) • Interface em russo 
 - Repacker Monkrus para diferentes aplicativos; altamente classificado, confiável e mais conhecido por seus repacks relacionados à Adobe.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/w16.monkrus.ws/) 
 ### 🧲 [Mac Torrents](https://www.torrentmac.net/) • MacOS 

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -10,8 +10,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 
 ## 🔰 ➜ Trackers Brasileiros
 
-:::warning Nota
-    Brsociety-pro é golpe! [Saiba mais.](https://t.me/CopyrightBR/1935)
+:::warning Brsociety-pro é golpe! [Saiba mais.](https://t.me/CopyrightBR/1935)
 :::
 
 ### 🧲 [Anime No Sekai](https://ansktracker.net/) | ANSK
@@ -81,8 +80,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 ---
 ## 🌐 ➜ Trackers Estrangeiros
 
-:::info Informação
-    **PU = Power User (usuário avançado):** primeira classificação quando você sobe de nível. Você precisa ter essa classificação para poder acessar o fórum de convites de um tracker.
+:::info **PU = Power User (usuário avançado):** primeira classificação quando você sobe de nível. Você precisa ter essa classificação para poder acessar o fórum de convites de um tracker.
 :::
 
 ### 🧲 [AlphaRatio](https://alpharatio.cc/) | AR

--- a/docs/warez.md
+++ b/docs/warez.md
@@ -11,7 +11,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Mídia digital, aplicativos para dispositivos móveis e pirataria voltada a educação. Aberto para cadastros. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/megaturbo.org/)
 
-### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [🔗](https://t.me/filewarezclub)
+### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [📣](https://t.me/filewarezclub)
 
 - Livros jurídicos, filmes, modelos 3D. Cadastro apenas com convite. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/filewarez.club/)

--- a/docs/warez.md
+++ b/docs/warez.md
@@ -11,7 +11,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Mídia digital, aplicativos para dispositivos móveis e pirataria voltada a educação. Aberto para cadastros. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/megaturbo.org/)
 
-### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [![](https://files.catbox.moe/7ad7g5.png)](https://t.me/filewarezclub)
+### 🏴‍☠️ [FileWarez 2.0](https://filewarez.club/) | FW [🔗](https://t.me/filewarezclub)
 
 - Livros jurídicos, filmes, modelos 3D. Cadastro apenas com convite. 
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/filewarez.club/)


### PR DESCRIPTION
https://popupoff.org/

Extensão que burla bloqueadores e pop-ups. Funciona no [Downloadcursosgratis](https://downloadcursos.gratis/) e [Rede Canais](https://redecanais.gs).

---

O que foi removido:

- Allow right click (Extensão/Userscript): função já existe no firefox com Shift + Seta direita + Botão direito do mouse.
- Cookie Auto Delete: Também já existe uma função para isso no firefox.

O que foi adicionado:

- Logo do telegram substituído por emoji de megafone 📣
- [MKVtoolnix](https://mkvtoolnix.download/)
- [Video DownloadHelper](https://www.downloadhelper.net/)
- [After Codecs](https://www.autokroma.com/AfterCodecs)
- [The Cutting Room Floor](https://tcrf.net)
- [Firedown](https://www.firedown.app/)
- [Allvasoft](https://www.allavsoft.com/)
- [Prism Cracked](https://github.com/Diegiwg/PrismLauncher-Cracked) 
- [HQ Now](https://www.hq-now.com/)
- [Port Authority](https://github.com/ACK-J/Port_Authority/)