### PR TITLE
Retirado duplicata do BJ share e outros trackers

### DIFF
--- a/docs/esportes.md
+++ b/docs/esportes.md
@@ -68,7 +68,7 @@ Esporte refere-se à atividade física ou jogo, geralmente competitivo, que util
 - Footballia é um site gringo onde você pode assistir a replays de jogos de futebol completos gratuitamente. Uma partida estará disponível no site 30 dias após ser transmitida.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/footballia.net/)
 
-:::info Acho que os sites abaixo só oferecem narrações em inglês 👇️.
+:::info Acho que os sites abaixo só oferecem narrações em inglês 👇️
 :::
 
 ### 📺️ [Rivestream](https://rivestream.live/livesports)

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -191,7 +191,7 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 
 ## 🧲 Torrents 
 
-### 🌟 [Stack Filmes](https://www.starckfilmes.com/) 
+### 🌟 [Starck Filmes](https://www.starckfilmes.com/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/www.starckfilmes.com/) 
 ### 🌟 [EZTV](https://eztvx.to/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/eztvx.to/) 
@@ -203,8 +203,6 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/bludv.xyz/) 
 ### 🧲 [Torrent dos Filmes.site](https://torrentdosfilmes.site/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/torrentdosfilmes.site/) 
-### 🧲 [ComandoFilmesHD.org](https://comandofilmeshd.org/) 
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/comandofilmeshd.org/) 
 ### 🧲 [Comando Filmes](https://comandofilmes.xyz/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/comandofilmes.xyz/) 
 ### 🧲 [Limon Torrents](https://limontorrents.com/) 

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -205,8 +205,6 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/torrentdosfilmes.site/) 
 ### 🧲 [Comando Filmes](https://comandofilmes.xyz/) 
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/comandofilmes.xyz/) 
-### 🧲 [Limon Torrents](https://limontorrents.com/) 
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/limontorrents.com) 
 
 ## 🖊️ Legendas 
 ### 🌟 [OpenSubtitles](https://www.opensubtitles.com) / [2](https://www.opensubtitles.org) 

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -160,7 +160,7 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - Fórum geral mais focado em TV onde os usuários oferecem listas IPTV.
 - Aqui estãos algumas threads populares com listas IPTV grátis: [1](https://htforum.net/forums/iptv-e-servicos-de-streaming.96/), [2](https://htforum.net/threads/lista-iptv-gratis.4288/) e [3](https://htforum.net/threads/iptv-gratis-tv-aberta.86/#).
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/htforum.net/) 
-### 🌟 [Rei dos Canais](https://reidoscanais.app/) 
+### 🌟 [Rei dos Canais](https://reidoscanais.vip/) 
 - Oferece Canais ao vivo com alta qualidade
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/reidoscanais.app/)   
 ### 📺️ [TV0800](https://tv0800.pro/) 

--- a/docs/sites-geral.md
+++ b/docs/sites-geral.md
@@ -85,7 +85,7 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 - Lar de alguns dos mais conhecidos repackers e crackers, bem como uma vasta coleção de arquivos torrent.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/1337x.to/)
 
-### 🌟 [Bitsearch](https://bitsearch.to/)
+### 🧲 [Bitsearch](https://bitsearch.to/)
 
 - Mecanismo de pesquisa avançado que simplesmente reúne metadados de torrent, como títulos de arquivo, tamanhos de arquivo e um link magnético para fornecer ao visitante.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/bitsearch.to/)
@@ -156,7 +156,7 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 - A estrela emergente do mundo p2p, com uma comunidade jovem, fresca e aberta onde você pode descobrir quase tudo.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/torrentgalaxy.to/)
 
-### 🧲 [TorrentLeech](https://www.torrentleech.org/) • Cadastre-se
+### 🌟 [TorrentLeech](https://www.torrentleech.org/) • Cadastre-se
 
 - Frequentemente são dados convites aos usuários deste cobiçado site rastreador privado, oferecendo torrents em todas as categorias em velocidades incomparáveis.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/torrentleech.org/)

--- a/docs/sites-geral.md
+++ b/docs/sites-geral.md
@@ -120,11 +120,6 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 - Um serviço de compartilhamento de arquivos ponto a ponto que oferece aos usuários uma variedade de conteúdo, como arquivos de música, arquivos de vídeo e arquivos de software.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/limetorrents.lol/)
 
-### 🧲 [MagnetDL](https://www.magnetdl.com/)
-
-- Software, filmes, jogos, ebooks, programas de TV e música são todos distribuídos por meio de links magnéticos por este agregador de torrent.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/magnetdl.com/)
-
 ### 🧲 [RARBG Dump Index](https://rarbgdump.com/)
 
 - Como um diretório de índice, o RARBG caído é preservado, com todos os rastreadores públicos novos e antigos adicionados.
@@ -135,7 +130,7 @@ Sites de múltiplos propósitos desde mecanismos de busca de torrent, agregadore
 - Fórum warez proeminente com notícias, discussões sobre muitos gêneros de mídia, torrents e links magnéticos também está disponível para download.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/rustorka.com/)
 
-### 🌟 [RuTracker](https://rutracker.org/forum/index.php) • Interface em russo
+### 🌟 [RuTracker](https://rutracker.net/) • Interface em russo
 
 - Tem uma vasta biblioteca com muitos gêneros diferentes. É bem distribuído e considerado o rastreador público mais abrangente.
 - Para usar a função de pesquisa, você precisa se cadastrar.

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -183,7 +183,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 ### 🧲 [Sktorrent](https://sktorrent.org/) 
 -  Tracker semi-privado focado em games.
 
-### 🧲 [Rutracker](https://rutracker.net/forum/index.php) 
+### 🧲 [Rutracker](https://rutracker.net/) 
 -  Tracker generalista russo.
 
 ➜ **[Veja a lista completa de trackers privados aqui](https://hdvinnie.github.io/Private-Trackers-Spreadsheet/)**

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -161,10 +161,12 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 ### 🧲 [TorrentLeech](https://www.torrentleech.org/) | TL
 - Tracker generalista.
 - Abrem para novos cadastros anualmente.
-
-### 🧲 [Academic Torrents](https://academictorrents.com/) | ACA
+ 
 ---
 ## 🚪 ➜ Trackers Públicos e semi-privados
+
+### 🧲 [Academic Torrents](https://academictorrents.com/)
+- Tracker público focado em educação.
 
 ### 🧲 [Tracker2.Postman](http://tracker2.postman.i2p) 
 - Tracker público na rede I2P.
@@ -184,7 +186,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 ### 🧲 [Rutracker](https://rutracker.net/forum/index.php) 
 -  Tracker generalista russo.
 
-➜ **[Veja a lista completa de trackers aqui](https://hdvinnie.github.io/Private-Trackers-Spreadsheet/)**
+➜ **[Veja a lista completa de trackers privados aqui](https://hdvinnie.github.io/Private-Trackers-Spreadsheet/)**
 
 **Está buscando sites para download de filmes e séries via torrent?**  
 Confira nossos tópicos sobre 🎦 [Filmes e TV](filmes-tv#🧲-torrents) e ⭐ [Anime](anime#📑-3-➜-torrents)

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -5,7 +5,7 @@ Trackers são servidores que requerem interação com um cliente de torrent, com
 Trackers podem ser públicos ou privados. Trackers públicos não demandam cadastro de usuários, podendo ser acessados por qualquer pessoa, enquanto trackers privados necessitam de cadastro para acesso. Trackers privados geralmente oferecem maior privacidade aos usuáruos e costumam ter uma retenção maior para os arquivos compartilhados, porém nem sempre é fácil conseguir acesso a eles. As principais formas de ingreso são: convite de usuários; entrevista; aplicação; recrutamento oficial em outros trackers privados, e quando abrem o site para novos usuários por tempo limitado.
 
 :::info ⚠️ Lembrete rápido
-Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisado quando novos Trackers abrirem cadastros. Verifique também mais sobre convites de trackers no [r/OpenSignups](https://www.reddit.com/r/OpenSignups/) e evite trackers amplamente prejudiciais para a [comunidade](https://www.reddit.com/r/OpenSignups/wiki/index/no-movement-list/).
+Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisado quando novos Trackers abrirem cadastros. Verifique também mais sobre convites de trackers no [r/OpenSignups](https://www.reddit.com/r/OpenSignups/) e evite trackers amplamente prejudiciais para a [comunidade](https://www.reddit.com/r/OpenSignups/wiki/index/banned-trackers/).
 :::
 
 ## 🔰 ➜ Trackers Brasileiros
@@ -23,11 +23,6 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Ativo desde 2019, um dos trackers de conteúdo geral BR mais antigos, atrás apenas do BJ.
 - Sistema de "doação" oficial em troca de convites.
 
-### 🧲 [BJ Share](https://bj-share.info/login.php?c) | BJ
-- Conteúdo geral/Gazelle.
-- O maior tracker nacional no momento. Aberto após o fim do antigo BJ.
-- BJ tem seedbox para torrents de filmes e séries antigas, fora disso tem poucos ou nenhum seed.
-
 ### 🧲 [Brasil Tracker](https://brasiltracker.org/index.php) | BT
 - Conteúdo geral/Gazelle.
 - Ativo desde 2018, parte da “santíssima trindade” dos trackers brasileiros junto com o ASC e o BJ.
@@ -39,6 +34,7 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Ativo desde 2002, é o tracker brasileiro mais tradicional.
 - Inicialmente operou como warez, migrou para torrent privado em 2016.
 - Acesso difícil, convites disponíveis apenas uma vez ao ano para usuários com status de overlord.
+- BJ tem seedbox para torrents de filmes e séries antigas, fora disso tem poucos ou nenhum seed.
 
 ### 🧲 [CapybaraBR](https://capybarabr.com/register) | CBR
 - Conteúdo geral/UNIT3D.

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -34,7 +34,6 @@ Participe de nosso [canal do Telegram](https://t.me/trackerslist) para ser avisa
 - Ativo desde 2002, é o tracker brasileiro mais tradicional.
 - Inicialmente operou como warez, migrou para torrent privado em 2016.
 - Acesso difícil, convites disponíveis apenas uma vez ao ano para usuários com status de overlord.
-- BJ tem seedbox para torrents de filmes e séries antigas, fora disso tem poucos ou nenhum seed.
 
 ### 🧲 [CapybaraBR](https://capybarabr.com/register) | CBR
 - Conteúdo geral/UNIT3D.


### PR DESCRIPTION
- [ComandofilmesHD](https://comandofilmeshd.org/)
- [LimonTorrents](https://limontorrents.com/) - Virou um site ucraniano
- [MagnetDL](https://magnetdl.com) - Possui um clone pouco confiável no momento
- [Academic Torrents](https://academictorrents.com/) foi movido para a parte de trackers públicos e semi-privados