### PR TITLE
Torna banner endof10 menos intrusivo, adiciona opção de fechar o banner e corrige erro de digitação

### DIFF
--- a/docs/.vitepress/theme/MyLayout.vue
+++ b/docs/.vitepress/theme/MyLayout.vue
@@ -1,14 +1,36 @@
 <script setup>
 import DefaultTheme from 'vitepress/theme'
+import { ref } from 'vue'
 
 const { Layout } = DefaultTheme
+
+const isBannerVisible = ref(true)
+
+function closeBanner() {
+  isBannerVisible.value = false
+}
 </script>
 
 <template>
   <Layout>
     <template #home-features-after>
-<section class="endof10"><a href="https://endof10.org/pt-br"><svg viewBox="0 0 688.235 754"><rect width="260.474" height="260.474" x="-36.543" y="129.876" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(-15.111)"></rect><rect width="260.474" height="260.474" x="407.612" y="96.465" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect><rect width="260.474" height="260.474" x="117.716" y="386.36" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect><rect width="260.474" height="260.474" x="486.185" y="332.836" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(7.911)"></rect></svg>
-<span>Continue usando seu PC após o término do suporte do Windows 10 agora em utubro. <strong>Visite endof10.org/pt-br</strong></span></a></section>
+      <section v-if="isBannerVisible" class="endof10">
+        <div class="banner-wrapper">
+          <a class="banner-link" href="https://endof10.org/pt-br">
+            <svg class="banner-icon" viewBox="0 0 688.235 754">
+              <rect width="260.474" height="260.474" x="-36.543" y="129.876" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(-15.111)"></rect>
+              <rect width="260.474" height="260.474" x="407.612" y="96.465" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect>
+              <rect width="260.474" height="260.474" x="117.716" y="386.36" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect>
+              <rect width="260.474" height="260.474" x="486.185" y="332.836" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(7.911)"></rect>
+            </svg>
+            <span class="banner-text">
+              Continue usando seu PC após o término do suporte do Windows 10 agora em outubro.
+              <strong>Visite endof10.org/pt-br</strong>
+            </span>
+          </a>
+        </div>
+        <button @click="closeBanner" class="close-banner" aria-label="Fechar Banner" title="Fechar Banner">×</button>
+      </section>
     </template>
   </Layout>
 </template>

--- a/docs/.vitepress/theme/MyLayout.vue
+++ b/docs/.vitepress/theme/MyLayout.vue
@@ -8,7 +8,7 @@ const { Layout } = DefaultTheme
   <Layout>
     <template #home-features-after>
 <section class="endof10"><a href="https://endof10.org/pt-br"><svg viewBox="0 0 688.235 754"><rect width="260.474" height="260.474" x="-36.543" y="129.876" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(-15.111)"></rect><rect width="260.474" height="260.474" x="407.612" y="96.465" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect><rect width="260.474" height="260.474" x="117.716" y="386.36" opacity=".4" rx="43.06" style="stroke-width:.920077"></rect><rect width="260.474" height="260.474" x="486.185" y="332.836" opacity=".4" rx="43.06" style="stroke-width:.920077" transform="rotate(7.911)"></rect></svg>
-<span>Continue usando seu PC após o término do suporte do Windows 11 agora em outubro. <strong>Visite endof10.org/pt-br</strong></span></a></section>
+<span>Continue usando seu PC após o término do suporte do Windows 10 agora em utubro. <strong>Visite endof10.org/pt-br</strong></span></a></section>
     </template>
   </Layout>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -232,45 +232,95 @@
 
 /* Thanks KDE project for the css banner */
 .endof10 {
-    margin-top: 1rem;
-    background: radial-gradient(at center top,#3477c8 0%,#13417b 75%);
-    padding: 1rem;
-    display: flex;
-    justify-content: center
+  position: relative;
+  margin: 32px 0;
+  background: radial-gradient(at center top, #3477c8 0%, #13417b 75%);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
 }
 
-.endof10>a {
-    font-weight: 300;
-    font-variation-settings: "wght" 300;
-    text-align: left;
-    display: flex;
-    flex-direction: row;
+.banner-wrapper {
+  width: 100%;
+  max-width: 960px;
+}
+
+.banner-link {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  color: #f6f5f4 !important;
+}
+
+.banner-icon {
+  fill: rgba(255, 255, 255, 0.8);
+  width: 52px;
+  height: auto;
+  flex-shrink: 0;
+}
+
+.banner-text {
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.banner-text strong {
+  display: block;
+  font-weight: 600;
+}
+
+.close-banner {
+  position: absolute;
+  top: 50%;
+  right: 32px;
+  transform: translateY(-50%);
+
+  background: none;
+  border: none;
+  color: white;
+  font-size: 26px;
+  font-weight: 300;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.close-banner:hover {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .endof10 {
+    margin: 24px 0;
+    padding: 0.75rem 1rem;
+    padding-right: 50px;
+  }
+
+  .banner-wrapper {
     gap: 1rem;
-    justify-content: space-between;
-    align-items: center;
-    max-width: 800px;
-    color: #f6f5f4!important
+  }
+
+  .banner-icon {
+    width: 44px;
+  }
+
+  .banner-text {
+    font-size: 14px;
+  }
+
+  .close-banner {
+    right: 16px;
+  }
 }
 
-.endof10>a:hover {
-    text-decoration: underline
-}
-
-.endof10 strong {
-    display: block;
-    font-weight: 500;
-    font-variation-settings: "wght" 500
-}
-
-.endof10 svg {
-    fill: #fff;
-    width: 64px;
-    height: auto;
-    margin: 1rem
-}
-
-@media only screen and (max-width: 700px) {
-    .endof10 svg {
-        width:30%
-    }
+@media (max-width: 480px) {
+  .banner-icon {
+    display: none;
+  }
 }


### PR DESCRIPTION
Ajusta o texto do banner para mencionar corretamente "Fim do Windows 10" (antes estava Windows 11). 

O banner foi levemente reduzido e pode ser fechado pelo usuário clicando no "x".