### PR TITLE
Atualizado o link do site principal do m0nkrus

### DIFF
--- a/docs/guias/guia-xdcc.md
+++ b/docs/guias/guia-xdcc.md
@@ -26,7 +26,7 @@ Mas como saber qual comando usar para receber um episódio específico de um ani
 Exemplos de packlists são:
 
 - Animes/Português:
-  - **AnimeNSK**: [https://packs.ansktracker.net/](https://packs.ansktracker.net/)
+  - **AnimeNSK**: [https://packs.ansktracker.net/](https://packs.ansktracker.net/) • RIP
   - **Eternal Animes**: [https://packs.eternalanimes.org/](https://packs.eternalanimes.org/)
   - **Lolicons Anônimos/Avalon Fansub**: [https://packs.cgnat.net/](https://packs.cgnat.net/)
 - Animes/Inglês:
@@ -41,7 +41,7 @@ Muitas vezes, na própria packlist, já é fornecida a informação do servidor 
 
 ## Na prática
 
-Para um exemplo prático, faremos o download do 1º episódio do anime _New Game!_ no tracker brasileiro _Anime no Sekai_, que possui uma packlist e bot xdcc em funcionamento, utilizando o client HexChat.
+Para um exemplo prático, faremos o download do 1º episódio do anime _New Game!_ no tracker brasileiro _Anime no Sekai_ (RIP), que possui uma packlist e bot xdcc em funcionamento, utilizando o client HexChat.
 
 1. Primeiramente, visitamos a tracklist na internet:
 

--- a/docs/musica.md
+++ b/docs/musica.md
@@ -79,6 +79,11 @@ A música é a habilidade de organizar o som para produzir qualquer combinação
 - Uma coleção impressionante e confiável de temas de OPs e EDs de anime com links diretos para conteúdo para download de alta qualidade.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/animethemes.moe/)
 
+### 🔗 [iTD Music](https://ww2.itdmusicy.com)
+
+- O melhor site para encontrar arquivos em M4A do iTunes Plus e para download de clipes musicais do Apple Music/Tidal.
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/ww2.itdmusicy.com/)
+
 ### 🔗 [Folksoundomy: Game Soundtracks](https://archive.org/details/folksoundomy_gamesoundtracks)
 
 - Uma seleção de músicas de videogame e algumas trilhas sonoras de anime criada por voluntários para ser o mais acessível possível.

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -255,7 +255,7 @@ Coleção de aplicações com arquivos de suporte e informações voltadas mais 
 
 ## 🧲 Torrent/P2P
 
-### 🌟 [M0nkrus](https://vk.com/monkrus) | [📣](https://t.me/m0nkrus/) • Interface em russo
+### 🌟 [M0nkrus](https://w18.monkrus.ws/) | [2](https://vk.com/monkrus) | [📣](https://t.me/m0nkrus/) • Interface em russo
 
 - Repacker para diferentes aplicativos **pré-instalados**; altamente classificado, confiável e mais conhecido por seus repacks relacionados a Creative Cloud e Autodesk Fusion.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/vk.com/)

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -258,7 +258,7 @@ Coleção de aplicações com arquivos de suporte e informações voltadas mais 
 ### 🌟 [M0nkrus](https://w18.monkrus.ws/) / [2](https://vk.com/monkrus) / [3](https://monkrus.dvuzu.com/) / [📣](https://t.me/real_monkrus/) • Interface em russo
 
 - Repacker para diferentes aplicativos **pré-instalados**; altamente classificado, confiável e mais conhecido por seus repacks relacionados a Creative Cloud e Autodesk Fusion.
-- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/vk.com/)
+- [Resultados de Segurança da URL](https://www.urlvoid.com/scan/w18.monkrus.ws/)
 
 ### 🌟 [Rutracker](https://rutracker.net/) / [2](https://rutracker.org/)
 

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -255,7 +255,7 @@ Coleção de aplicações com arquivos de suporte e informações voltadas mais 
 
 ## 🧲 Torrent/P2P
 
-### 🌟 [M0nkrus](https://w18.monkrus.ws/) | [2](https://vk.com/monkrus) | [📣](https://t.me/m0nkrus/) • Interface em russo
+### 🌟 [M0nkrus](https://w18.monkrus.ws/) | [2](https://vk.com/monkrus) | [📣](https://t.me/real_monkrus/) • Interface em russo
 
 - Repacker para diferentes aplicativos **pré-instalados**; altamente classificado, confiável e mais conhecido por seus repacks relacionados a Creative Cloud e Autodesk Fusion.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/vk.com/)

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -255,7 +255,7 @@ Coleção de aplicações com arquivos de suporte e informações voltadas mais 
 
 ## 🧲 Torrent/P2P
 
-### 🌟 [M0nkrus](https://w18.monkrus.ws/) | [2](https://vk.com/monkrus) | [📣](https://t.me/real_monkrus/) • Interface em russo
+### 🌟 [M0nkrus](https://w18.monkrus.ws/) / [2](https://vk.com/monkrus) / [3](https://monkrus.dvuzu.com/) / [📣](https://t.me/real_monkrus/) • Interface em russo
 
 - Repacker para diferentes aplicativos **pré-instalados**; altamente classificado, confiável e mais conhecido por seus repacks relacionados a Creative Cloud e Autodesk Fusion.
 - [Resultados de Segurança da URL](https://www.urlvoid.com/scan/vk.com/)

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -13,13 +13,6 @@ Participe de nosso [grupo do lemmy](https://lemmy.dbzer0.com/c/pirataria) para s
 :::danger 💣 Brsociety-pro é golpe! [Saiba mais.](https://t.me/CopyrightBR/1935)
 :::
 
-### 🧲 [Anime No Sekai](https://ansktracker.net/) | ANSK
-
-- Tracker de lançamentos internos da fansub ANSK
-- **Freeleech disponível em todo o site devido ao encerramento das atividades.**
-- Oferece um bot XDCC público para download de packs via IRC.
-- Sem suporte a automação.
-
 ### 🧲 [Amigos Share Club](https://cliente.amigos-share.club/) | ASC
 
 - Conteúdo geral/UNIT3D.


### PR DESCRIPTION
Adicionei novamente o link do site principal do m0nkrus (faz algum tempo que ele já retornou com o acesso).

Mantive o link da página do VK e telegram dele.