### PR TITLE
feat: add AnonDL - download de centenas de sites (self-hosted)

### DIFF
--- a/docs/ferramentas.md
+++ b/docs/ferramentas.md
@@ -322,6 +322,7 @@ Estes são sites que rastreiam os lançamentos da Scene. Eles servem estritament
 ## ► Ferramentas de download on-line
 
 - 🌟 [**Cobalt**](https://cobalt.tools/) - Baixe vídeos/áudios do tiktok, reddit, twitter e outros sites. Se a instância principal não funcionar com o YouTube, você pode tentar outras instâncias (as marcadas em verde são as mais seguras): https://cobalt.directory/.
+- 🌟 [**AnonDL**](https://download.baguncinha.online/) - Baixe vídeos e áudios de centenas de sites anonimamente (YouTube, Instagram, TikTok, Twitter/X, Reddit, YouTube Music, sites de streaming pirata e muito mais), sem limites de tamanho, sem anúncios e sem logs. Instância self-hosted baseada no yt-dlp com suporte a múltiplas qualidades (até 4K) e formato MP3.
 - [9xbuddy](https://9xbuddy.com/) - Youtube / site para download de mídia de várias plataformas.
 - [calameodownload](https://calameodownload.com/) - Uma ferramenta online gratuita para baixar qualquer documento público do Calameo como imagens ou PDFs. Acesse o site com uma VPN.
 - [Cnvmp3](https://cnvmp3.com/) - Converta vídeos do YouTube para MP3 ou MP4 e baixe-os com este conversor rápido e gratuito do YouTube. O CnvMP3 é livre de anúncios, seguro e suporta qualidade de até 320 kbps.


### PR DESCRIPTION
- Adiciona AnonDL (https://download.baguncinha.online/) à seção de ferramentas de download online
- Self-hosted, anônimo, baseado no yt-dlp
- Suporta YouTube, Instagram, TikTok, Twitter/X, Reddit, YouTube Music, sites de streaming pirata e mais
- Sem anúncios, sem logs, Downloads de até 2GB 
- Múltiplas qualidades (até 4K) e formato MP3