### PR TITLE
docs: adiciona BRFLIX TV nas seções de TV e Transmissão ao vivo

### DIFF
--- a/docs/esportes.md
+++ b/docs/esportes.md
@@ -17,12 +17,6 @@ Esporte refere-se à atividade física ou jogo, geralmente competitivo, que util
 
 ## 🖥 **Transmissão ao vivo**
 
-### 📺️ [BRFLIX TV](https://brflix.online/)
-
-- Transmissões esportivas ao vivo com múltiplos servidores HD.
-- Cobertura completa de futebol (Brasilão Série A e B, Copa do Brasil, Libertadores, Copa Sul-Americana, Champions League, Premier League, La Liga, Serie A e Bundesliga), além de eventos de Fórmula 1, NBA e UFC.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
-
 ### 🌟 [Rede Canais TV](https://redecanaistv.gs/) / [2](https://redecanaistv.fi/) / [3](https://redecanaistv.ps/)
 
 - Oferece uma ampla gama de canais ao vivo com a mais alta qualidade de transmissão. [Falha na conexão? Tente isso.](guias/dns.md)
@@ -35,10 +29,11 @@ Esporte refere-se à atividade física ou jogo, geralmente competitivo, que util
 - MMA, SporTV, ESPN do Brasil e Internacional - anúncios enfadonhos existem mas podem ser burlados com o PopUpOFF.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/multicanaishd.bid/)
 
-### 🌟 [EmbedCanais](https://embedcanais.com/)
+### 📺️ [BRFLIX TV](https://brflix.online/)
 
-- Reúne em um só lugar o TNT Brasil, Pacote Premiere, Combate TV e noticiário de interesse local/internacional. Abra o player e copie o iframe para incorporar o vídeo no seu site ou projeto pessoal com poucos cliques.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/embedcanais.com/)
+- Transmissões esportivas ao vivo com múltiplos servidores HD.
+- Cobertura completa de futebol (Brasilão Série A e B, Copa do Brasil, Libertadores, Copa Sul-Americana, Champions League, Premier League, La Liga, Serie A e Bundesliga), além de eventos de Fórmula 1, NBA e UFC.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
 
 ### 📺️ [Betterflix](https://betterflix.click/canais?lang=pt) / [API](https://betterflix.click/api)
 

--- a/docs/esportes.md
+++ b/docs/esportes.md
@@ -17,6 +17,12 @@ Esporte refere-se à atividade física ou jogo, geralmente competitivo, que util
 
 ## 🖥 **Transmissão ao vivo**
 
+### 📺️ [BRFLIX TV](https://brflix.online/)
+
+- Transmissões esportivas ao vivo com múltiplos servidores HD.
+- Cobertura completa de futebol (Brasilão Série A e B, Copa do Brasil, Libertadores, Copa Sul-Americana, Champions League, Premier League, La Liga, Serie A e Bundesliga), além de eventos de Fórmula 1, NBA e UFC.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
+
 ### 🌟 [Rede Canais TV](https://redecanaistv.gs/) / [2](https://redecanaistv.fi/) / [3](https://redecanaistv.ps/)
 
 - Oferece uma ampla gama de canais ao vivo com a mais alta qualidade de transmissão. [Falha na conexão? Tente isso.](guias/dns.md)

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -29,12 +29,6 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - Interface moderna e responsiva, totalmente otimizada para computadores, dispositivos móveis e Smart TVs.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.lat/)
 
-### 📺️ [BRFLIX TV](https://brflix.online/)
-
-- Transmissão ao vivo de canais de TV aberta, fechada, esportes e grandes eventos ao vivo.
-- Cobertura dos principais campeonatos como Brasilão Série A e B, Copa do Brasil, Libertadores, Sul-Americana, Champions League, Premier League, La Liga, além de Fórmula 1, NBA e UFC.
-- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
-
 ### 🌟 [Pomfy](https://pomfy.online/) / [2](https://pomfy.stream/) / [API](https://api.pomfy.stream/)
 
 - O Pomfy é um espaço com milhares de filmes e séries internacionais e nacionais, disponível tanto no idioma original, quanto dublado; sempre na melhor qualidade.
@@ -221,6 +215,12 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - Oferece canais ao vivo e streaming de eventos esportivos como UFC e Libertadores assim que são iniciados.
 - Anúncios enfadonhos existem mas estes podem ser burlados com o PopUpOFF.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/multicanaishd.bid/)
+
+### 📺️ [BRFLIX TV](https://brflix.online/)
+
+- Transmissão ao vivo de canais de TV aberta, fechada, esportes e grandes eventos ao vivo.
+- Cobertura dos principais campeonatos como Brasilão Série A e B, Copa do Brasil, Libertadores, Sul-Americana, Champions League, Premier League, La Liga, além de Fórmula 1, NBA e UFC.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
 
 ### 🔗 [Betterflix](https://betterflix.click/canais?lang=pt) / [API](https://betterflix.click/api)
 

--- a/docs/filmes-tv.md
+++ b/docs/filmes-tv.md
@@ -29,6 +29,12 @@ Filmes e TV são obras de arte visual que empregam imagens em movimento para imi
 - Interface moderna e responsiva, totalmente otimizada para computadores, dispositivos móveis e Smart TVs.
 - [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.lat/)
 
+### 📺️ [BRFLIX TV](https://brflix.online/)
+
+- Transmissão ao vivo de canais de TV aberta, fechada, esportes e grandes eventos ao vivo.
+- Cobertura dos principais campeonatos como Brasilão Série A e B, Copa do Brasil, Libertadores, Sul-Americana, Champions League, Premier League, La Liga, além de Fórmula 1, NBA e UFC.
+- [Resultados de segurança da URL](https://www.urlvoid.com/scan/brflix.online/)
+
 ### 🌟 [Pomfy](https://pomfy.online/) / [2](https://pomfy.stream/) / [API](https://api.pomfy.stream/)
 
 - O Pomfy é um espaço com milhares de filmes e séries internacionais e nacionais, disponível tanto no idioma original, quanto dublado; sempre na melhor qualidade.


### PR DESCRIPTION
## Adiciona BRFLIX TV

Adiciona o [BRFLIX TV](https://brflix.online/) em duas seções:

- **📺️ TV** em `docs/filmes-tv.md` (logo abaixo do BRFLIX)
- **🖥 Transmissão ao vivo** em `docs/esportes.md`

O BRFLIX TV oferece transmissão ao vivo de canais de TV aberta, fechada e esportes, com cobertura dos principais campeonatos (Brasilão, Libertadores, Champions League, Premier League, etc.) além de Fórmula 1, NBA e UFC.