### PR TITLE
docs: adiciona AnimesIce na seção Otaku

### DIFF
--- a/docs/otaku.md
+++ b/docs/otaku.md
@@ -81,6 +81,11 @@ Lista que engloba tudo referente à cultura japonesa, embora possa ter também s
 #### ▶️ [Animesonlinecc](https://animesonlinecc.to)
 
 - [Verificação de segurança da URL](https://www.urlvoid.com/scan/animesonlinecc.org/)
+
+#### ▶️ [AnimesIce](https://animesice.app)
+
+- Site brasileiro de streaming de animes com catálogo em boa qualidade, lançamentos atualizados automaticamente, listas personalizadas e comunidade integrada.
+- [Verificação de segurança da URL](https://www.urlvoid.com/scan/animesice.app/)
  ‎
  ‎
 ### 📥 ➜ Download Direto


### PR DESCRIPTION
## Alterações

Adiciona o **AnimesIce** (`https://animesice.app`) na seção `🎎 ➜ Anime → 🖥 ➜ Streaming` do `docs/otaku.md`, seguindo o formato existente.

**Nome do site e URL:** AnimesIce — https://animesice.app

## Por que seria útil para a comunidade

- **Site nacional** (brasileiro) de streaming de animes, em PT-BR.
- Catálogo em boa qualidade com lançamentos atualizados automaticamente.
- Recursos de organização (listas personalizadas, favoritos) e comunidade integrada (perfis, posts).

## Verificação de segurança

- **URLVoid:** [animesice.app](https://www.urlvoid.com/scan/animesice.app/) — sem avisos, nenhuma blacklist/detecção encontrada (report not found = sem sinalizações).
- **Idade do domínio:** registrado em 05/08/2026 (recente, ~2 semanas) junto ao registrador Name.com; site ativo e funcional (HTTP 200), hospedado atrás de Cloudflare.
- **Reputação:** desenvolvimento público no GitHub (`1arley/animesice-web` e `1arley/animesice-back`), sem histórico de malware.